### PR TITLE
This PR fixes 5 issues thanks to snyk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 openjdk:11.0.13-slim-buster
+FROM --platform=linux/amd64 openjdk:11.0.16-jdk-slim-bullseye
 #FROM --platform=linux/amd64 openjdk:21-slim-bullseye
 
 RUN addgroup --system javauser && adduser --system --home /home/javauser --ingroup javauser javauser


### PR DESCRIPTION
It updates openjdk from version 11.0.13-slim-buster to version 11.0.16-jdk-slim-bullseye.
Review relevant docs for possible breaking changes.


To find more details, see the Snyk project [22521100&#x2F;snyk-boot-web:Dockerfile](https:&#x2F;&#x2F;app.snyk.io&#x2F;org&#x2F;22521100&#x2F;project&#x2F;96275538-5690-4c90-8810-a90080f3a01b?utm_source&#x3D;github&amp;utm_medium&#x3D;referral&amp;page&#x3D;fix-pr)


[//]: # 'snyk:metadata:{"customTemplate":{"variablesUsed":["issue_count","package_name","package_from","package_to","snyk_project_name","snyk_project_url"],"fieldsUsed":["commitMessage","description","title"]},"dependencies":[{"name":"openjdk","from":"11.0.13-slim-buster","to":"11.0.16-jdk-slim-bullseye"}],"env":"prod","issuesToFix":["SNYK-DEBIAN10-SYSTEMD-3339153","SNYK-DEBIAN10-SYSTEMD-3339153","SNYK-DEBIAN10-DPKG-2847944","SNYK-DEBIAN10-OPENSSL-2807585","SNYK-DEBIAN10-GLIBC-1296899"],"prId":"42452930-98b8-44ef-82aa-83f14cf777f0","prPublicId":"42452930-98b8-44ef-82aa-83f14cf777f0","packageManager":"dockerfile","priorityScoreList":[786,714,714,714],"projectPublicId":"96275538-5690-4c90-8810-a90080f3a01b","projectUrl":"https://app.snyk.io/org/22521100/project/96275538-5690-4c90-8810-a90080f3a01b?utm_source=github&utm_medium=referral&page=fix-pr","prType":"fix","templateFieldSources":{"branchName":"default","commitMessage":"repository","description":"repository","title":"repository"},"templateVariants":["custom","updated-fix-title","priorityScore"],"type":"user-initiated","upgrade":["SNYK-DEBIAN10-DPKG-2847944","SNYK-DEBIAN10-GLIBC-1296899","SNYK-DEBIAN10-OPENSSL-2807585","SNYK-DEBIAN10-SYSTEMD-3339153","SNYK-DEBIAN10-SYSTEMD-3339153"],"vulns":["SNYK-DEBIAN10-SYSTEMD-3339153","SNYK-DEBIAN10-DPKG-2847944","SNYK-DEBIAN10-OPENSSL-2807585","SNYK-DEBIAN10-GLIBC-1296899"],"patch":[],"isBreakingChange":false,"remediationStrategy":"vuln"}'